### PR TITLE
Bundle sqlite with receptor compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,5 @@ Make the Web UI mobile friendly
 
 
 <a href="#"><img alt="Feature" src="https://i.imgur.com/onvKoVz.png" height="28" width="28"></a>
-Add SQLite compilation as part of the build and link with it statically
-
-
-<a href="#"><img alt="Feature" src="https://i.imgur.com/onvKoVz.png" height="28" width="28"></a>
 Add some more plugin to the receptor side of things, such as average resource usage plugin, text diff check (to, for example, check the differences between running
     the same command on multiple machine)... etc

--- a/receptor/Cargo.toml
+++ b/receptor/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["George Hosu <george@cerebralab.com>"]
 build = "build.rs"
 
 [dependencies]
-rusqlite = "0.13.0"
-
 tokio-core = "0.1.15"
 tokio = "0.1.3"
 futures = "0.1.18"
@@ -26,6 +24,10 @@ walkdir = "2"
 
 hyper = "0.11"
 hyper-staticfile = "0.1.1"
+
+[dependencies.rusqlite]
+version = "0.11.0"
+features = ["bundled"]
 
 [features]
 default = []


### PR DESCRIPTION
Per doc "If you use the bundled feature, libsqlite3-sys will use the gcc crate to compile SQLite from source and link against that."