### PR TITLE
Better sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,5 @@ Make the Web UI mobile friendly
 
 
 <a href="#"><img alt="Feature" src="https://i.imgur.com/onvKoVz.png" height="28" width="28"></a>
-Add SQLite compilation as part of the build and link with it statically
-
-
-<a href="#"><img alt="Feature" src="https://i.imgur.com/onvKoVz.png" height="28" width="28"></a>
 Add some more plugin to the receptor side of things, such as average resource usage plugin, text diff check (to, for example, check the differences between running
     the same command on multiple machine)... etc

--- a/agent/agent_lib/Cargo.toml
+++ b/agent/agent_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent_lib"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]

--- a/agent/agent_lib/src/lib.rs
+++ b/agent/agent_lib/src/lib.rs
@@ -4,4 +4,5 @@ pub trait AgentPlugin {
     fn name(&self) -> String;
     fn gather(&mut self) -> Result<String, String>;
     fn ready(&self) -> bool;
+    fn when_ready(&self) -> i64;
 }

--- a/agent/agent_lib/src/lib.rs
+++ b/agent/agent_lib/src/lib.rs
@@ -3,6 +3,8 @@ pub mod utils;
 pub trait AgentPlugin {
     fn name(&self) -> String;
     fn gather(&mut self) -> Result<String, String>;
-    fn ready(&self) -> bool;
+    fn ready(&self) -> bool {
+        self.when_ready() < 0
+    }
     fn when_ready(&self) -> i64;
 }

--- a/agent/agent_lib/src/utils.rs
+++ b/agent/agent_lib/src/utils.rs
@@ -8,10 +8,10 @@ use std::env::current_exe;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn current_ts() -> i64 {
-    return SystemTime::now()
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Error getting system time !?")
-        .as_secs() as i64;
+        .as_secs() as i64
 }
 
 pub fn get_yml_config(name: &str) -> Yaml {
@@ -20,5 +20,5 @@ pub fn get_yml_config(name: &str) -> Yaml {
     cfg_file_path.push(name);
     let contents = read_to_string(&cfg_file_path).unwrap();
     let mut docs = YamlLoader::load_from_str(&contents).unwrap();
-    return docs.remove(0);
+    docs.remove(0)
 }

--- a/agent/agent_plugins/alive/Cargo.toml
+++ b/agent/agent_plugins/alive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alive"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]

--- a/agent/agent_plugins/alive/src/lib.rs
+++ b/agent/agent_plugins/alive/src/lib.rs
@@ -55,4 +55,11 @@ impl AgentPlugin for Plugin {
         }
         self.last_call_ts + self.periodicity < utils::current_ts()
     }
+
+    fn when_ready(&self) -> i64 {
+        if self.disable {
+            return 999;
+        }
+        utils::current_ts() - self.last_call_ts + self.periodicity
+    }
 }

--- a/agent/agent_plugins/alive/src/lib.rs
+++ b/agent/agent_plugins/alive/src/lib.rs
@@ -48,14 +48,7 @@ impl AgentPlugin for Plugin {
         self.last_call_ts = utils::current_ts();
         Ok(String::from("I live"))
     }
-
-    fn ready(&self) -> bool {
-        if self.disable {
-            return false;
-        }
-        self.last_call_ts + self.periodicity < utils::current_ts()
-    }
-
+    
     fn when_ready(&self) -> i64 {
         if self.disable {
             return 999;

--- a/agent/agent_plugins/command_runner/Cargo.toml
+++ b/agent/agent_plugins/command_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command_runner"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]

--- a/agent/agent_plugins/command_runner/src/lib.rs
+++ b/agent/agent_plugins/command_runner/src/lib.rs
@@ -103,7 +103,7 @@ impl AgentPlugin for Plugin {
         }
         self.last_call_map
             .iter()
-            .any(|(k, v)| v + self.periodicity_map.get(k).unwrap() < utils::current_ts())
+            .any(|(k, v)| v + self.periodicity_map[k] < utils::current_ts())
     }
 
     fn when_ready(&self) -> i64 {
@@ -112,10 +112,7 @@ impl AgentPlugin for Plugin {
         }
         use std::cmp::min;
         self.last_call_map.iter().fold(999, |m, (k, v)| {
-            min(
-                m,
-                utils::current_ts() - v + self.periodicity_map.get(k).unwrap(),
-            )
+            min(m, utils::current_ts() - v + self.periodicity_map[k])
         })
     }
 }

--- a/agent/agent_plugins/command_runner/src/lib.rs
+++ b/agent/agent_plugins/command_runner/src/lib.rs
@@ -97,15 +97,6 @@ impl AgentPlugin for Plugin {
         Ok(serde_json::to_string(&results).expect("Can't serialize command result map"))
     }
 
-    fn ready(&self) -> bool {
-        if self.disable {
-            return false;
-        }
-        self.last_call_map
-            .iter()
-            .any(|(k, v)| v + self.periodicity_map[k] < utils::current_ts())
-    }
-
     fn when_ready(&self) -> i64 {
         if self.disable {
             return 999;

--- a/agent/agent_plugins/command_runner/src/lib.rs
+++ b/agent/agent_plugins/command_runner/src/lib.rs
@@ -101,13 +101,21 @@ impl AgentPlugin for Plugin {
         if self.disable {
             return false;
         }
-        for (name, _) in &self.last_call_map {
-            if self.last_call_map.get(name).unwrap() + self.periodicity_map.get(name).unwrap()
-                < utils::current_ts()
-            {
-                return true;
-            }
+        self.last_call_map
+            .iter()
+            .any(|(k, v)| v + self.periodicity_map.get(k).unwrap() < utils::current_ts())
+    }
+
+    fn when_ready(&self) -> i64 {
+        if self.disable {
+            return 999;
         }
-        false
+        use std::cmp::min;
+        self.last_call_map.iter().fold(999, |m, (k, v)| {
+            min(
+                m,
+                utils::current_ts() - v + self.periodicity_map.get(k).unwrap(),
+            )
+        })
     }
 }

--- a/agent/agent_plugins/file_checker/Cargo.toml
+++ b/agent/agent_plugins/file_checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filechecker"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]

--- a/agent/agent_plugins/file_checker/src/lib.rs
+++ b/agent/agent_plugins/file_checker/src/lib.rs
@@ -134,4 +134,11 @@ impl AgentPlugin for Plugin {
         }
         self.last_call_ts + self.periodicity < utils::current_ts()
     }
+
+    fn when_ready(&self) -> i64 {
+        if self.disable {
+            return 999;
+        }
+        utils::current_ts() - self.last_call_ts + self.periodicity
+    }
 }

--- a/agent/agent_plugins/file_checker/src/lib.rs
+++ b/agent/agent_plugins/file_checker/src/lib.rs
@@ -126,13 +126,6 @@ impl AgentPlugin for Plugin {
         }
     }
 
-    fn ready(&self) -> bool {
-        if self.disable {
-            return false;
-        }
-        self.last_call_ts + self.periodicity < utils::current_ts()
-    }
-
     fn when_ready(&self) -> i64 {
         if self.disable {
             return 999;

--- a/agent/agent_plugins/file_checker/src/lib.rs
+++ b/agent/agent_plugins/file_checker/src/lib.rs
@@ -102,10 +102,8 @@ impl AgentPlugin for Plugin {
                 for line_res in BufReader::new(fp).lines() {
                     let line = line_res.unwrap();
                     line_nr += 1;
-                    if line_nr > file_info.last_line {
-                        if line.contains(&file_info.look_for) {
-                            results.push((file_name.clone(), format!("{}: {}", line_nr, line)));
-                        }
+                    if line_nr > file_info.last_line && line.contains(&file_info.look_for) {
+                        results.push((file_name.clone(), format!("{}: {}", line_nr, line)));
                     }
                 }
                 let new_file_info = FileInfo {
@@ -121,7 +119,7 @@ impl AgentPlugin for Plugin {
             self.file_info_map.insert(t.0, t.1);
         }
 
-        if results.len() > 0 {
+        if !results.is_empty() {
             Ok(serde_json::to_string(&results).expect("Can't serialize command result map"))
         } else {
             Err(String::from("Nothing to read"))

--- a/agent/agent_plugins/process_counter/Cargo.toml
+++ b/agent/agent_plugins/process_counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process_counter"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]

--- a/agent/agent_plugins/process_counter/src/lib.rs
+++ b/agent/agent_plugins/process_counter/src/lib.rs
@@ -94,15 +94,6 @@ impl AgentPlugin for Plugin {
         Ok(serde_json::to_string(&results).expect("Can't serialize command result map"))
     }
 
-    fn ready(&self) -> bool {
-        if self.disable {
-            return false;
-        }
-        self.last_call_map
-            .iter()
-            .any(|(k, v)| v + self.periodicity_map[k] < utils::current_ts())
-    }
-
     fn when_ready(&self) -> i64 {
         if self.disable {
             return 999;

--- a/agent/agent_plugins/process_counter/src/lib.rs
+++ b/agent/agent_plugins/process_counter/src/lib.rs
@@ -82,8 +82,8 @@ impl AgentPlugin for Plugin {
 
             if output.status.success() {
                 let str_output = String::from_utf8(output.stdout).unwrap();
-                if str_output.len() > 0 {
-                    let v: Vec<&str> = str_output.split("\n").filter(|&x| x != "").collect();
+                if !str_output.is_empty() {
+                    let v: Vec<&str> = str_output.split('\n').filter(|&x| x != "").collect();
                     running = v.len() as i64;
                 }
             }
@@ -100,7 +100,7 @@ impl AgentPlugin for Plugin {
         }
         self.last_call_map
             .iter()
-            .any(|(k, v)| v + self.periodicity_map.get(k).unwrap() < utils::current_ts())
+            .any(|(k, v)| v + self.periodicity_map[k] < utils::current_ts())
     }
 
     fn when_ready(&self) -> i64 {
@@ -109,10 +109,7 @@ impl AgentPlugin for Plugin {
         }
         use std::cmp::min;
         self.last_call_map.iter().fold(999, |m, (k, v)| {
-            min(
-                m,
-                utils::current_ts() - v + self.periodicity_map.get(k).unwrap(),
-            )
+            min(m, utils::current_ts() - v + self.periodicity_map[k])
         })
     }
 }

--- a/agent/agent_plugins/process_counter/src/lib.rs
+++ b/agent/agent_plugins/process_counter/src/lib.rs
@@ -98,13 +98,21 @@ impl AgentPlugin for Plugin {
         if self.disable {
             return false;
         }
-        for (name, _) in &self.last_call_map {
-            if self.last_call_map.get(name).unwrap() + self.periodicity_map.get(name).unwrap()
-                < utils::current_ts()
-            {
-                return true;
-            }
+        self.last_call_map
+            .iter()
+            .any(|(k, v)| v + self.periodicity_map.get(k).unwrap() < utils::current_ts())
+    }
+
+    fn when_ready(&self) -> i64 {
+        if self.disable {
+            return 999;
         }
-        false
+        use std::cmp::min;
+        self.last_call_map.iter().fold(999, |m, (k, v)| {
+            min(
+                m,
+                utils::current_ts() - v + self.periodicity_map.get(k).unwrap(),
+            )
+        })
     }
 }

--- a/agent/agent_plugins/system_monitor/Cargo.toml
+++ b/agent/agent_plugins/system_monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system_monitor"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]

--- a/agent/agent_plugins/system_monitor/src/lib.rs
+++ b/agent/agent_plugins/system_monitor/src/lib.rs
@@ -100,11 +100,11 @@ impl AgentPlugin for Plugin {
         network_map.insert("out", format!("{}", network.get_outcome()));
 
         let machine_state = MachineState {
-            fs_state: fs_state,
-            memory_map: memory_map,
-            swap_map: swap_map,
-            processor_map: processor_map,
-            network_map: network_map,
+            fs_state,
+            memory_map,
+            swap_map,
+            processor_map,
+            network_map,
         };
         Ok(serde_json::to_string(&machine_state).expect("Can't serialize fs_state"))
     }

--- a/agent/agent_plugins/system_monitor/src/lib.rs
+++ b/agent/agent_plugins/system_monitor/src/lib.rs
@@ -109,13 +109,6 @@ impl AgentPlugin for Plugin {
         Ok(serde_json::to_string(&machine_state).expect("Can't serialize fs_state"))
     }
 
-    fn ready(&self) -> bool {
-        if self.disable {
-            return false;
-        }
-        self.last_call_ts + self.periodicity < utils::current_ts()
-    }
-
     fn when_ready(&self) -> i64 {
         if self.disable {
             return 999;

--- a/agent/agent_plugins/system_monitor/src/lib.rs
+++ b/agent/agent_plugins/system_monitor/src/lib.rs
@@ -115,4 +115,11 @@ impl AgentPlugin for Plugin {
         }
         self.last_call_ts + self.periodicity < utils::current_ts()
     }
+
+    fn when_ready(&self) -> i64 {
+        if self.disable {
+            return 999;
+        }
+        utils::current_ts() - self.last_call_ts + self.periodicity
+    }
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -35,7 +35,6 @@ fn main() {
 
     let mut sender = StatusSender::new(hostanme, addr);
     loop {
-        thread::sleep(time::Duration::from_millis(1000));
         let mut payload = Vec::new();
 
         for mut p in &mut plugins {
@@ -53,6 +52,9 @@ fn main() {
 
             tokio::run(send);
         }
+
+        let s = &plugins.iter().min_by_key(|x| x.when_ready()).unwrap();
+        thread::sleep(time::Duration::from_secs(s.when_ready() as u64));
     }
 }
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
         config["receptor"]["port"].as_i64().unwrap()
     );
 
-    let mut sender = StatusSender::new(hostanme, addr);
+    let mut sender = StatusSender::new(hostanme, addr.parse().expect("Couldn't convert IP address"));
     loop {
         let mut payload = Vec::new();
 
@@ -64,10 +64,10 @@ struct StatusSender {
 }
 
 impl StatusSender {
-    fn new(hostname: String, addr_str: String) -> StatusSender {
+    fn new(hostname: String, addr: std::net::SocketAddr) -> StatusSender {
         StatusSender {
-            addr: addr_str.parse().unwrap(),
-            hostname: hostname,
+            addr,
+            hostname,
         }
     }
 

--- a/agent/src/status.rs
+++ b/agent/src/status.rs
@@ -1,5 +1,3 @@
-use std::string::String;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Status {
     pub sender: String,

--- a/receptor/Cargo.toml
+++ b/receptor/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["George Hosu <george@cerebralab.com>"]
 build = "build.rs"
 
 [dependencies]
-rusqlite = "0.13.0"
-
 tokio-core = "0.1.15"
 tokio = "0.1.3"
 futures = "0.1.18"
@@ -26,6 +24,10 @@ walkdir = "2"
 
 hyper = "0.11"
 hyper-staticfile = "0.1.1"
+
+[dependencies.rusqlite]
+version = "0.11.0"
+features = ["bundled"]
 
 [features]
 default = []


### PR DESCRIPTION
Agent now sleeps the required amount of time rather than one second every loop.

In theory, we could get rid of the existing ready function and if when_ready is negative then we run. I don't think it's worth it though.

Last two commits aren't related to this trait change directly, apologies if it causes conflicts with any of your work.