### PR TITLE
Dependency update + Clippy

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -4,13 +4,12 @@ version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
-serde = "1.0"
-serde_json = "1.0"
-tokio = "0.1.3"
-futures = "0.1.18"
-log = "0.4.0"
+serde = "1.0.37"
+serde_json = "1.0.13"
+tokio = "0.1.5"
+log = "0.4.1"
 env_logger = "0.5.6"
-hostname = "^0.1"
+hostname = "0.1.4"
 
 agent_lib = {path="agent_lib"}
 plugins = {path="plugins"}

--- a/agent/agent_lib/Cargo.toml
+++ b/agent/agent_lib/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Richard Petrie <rap1011@ksu.edu>"]
 
 [dependencies]
 fs_extra = "1.1.0"
-sysinfo = "0.5.1"
-yaml-rust = "0.4"
+sysinfo = "0.5.4"
+yaml-rust = "0.4.0"
 shared_lib = {path="../../shared_lib"}

--- a/agent/agent_plugins/alive/Cargo.toml
+++ b/agent/agent_plugins/alive/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 agent_lib = {path="../../agent_lib"}
-serde = "1.0"
-serde_derive = "1.0"
+serde = "1.0.37"
+serde_derive = "1.0.37"

--- a/agent/agent_plugins/alive/src/lib.rs
+++ b/agent/agent_plugins/alive/src/lib.rs
@@ -28,10 +28,9 @@ impl Plugin {
 	fn config(&mut self) -> Result<(), String> {
 		let cfg = read_cfg::<Config>("alive.yml")?;
 		self.enabled = cfg.enabled;
-		if !self.enabled {
-			return Ok(());
+		if self.enabled {
+			self.periodicity = cfg.periodicity;
 		}
-		self.periodicity = cfg.periodicity;
 		Ok(())
 	}
 }

--- a/agent/agent_plugins/alive/src/lib.rs
+++ b/agent/agent_plugins/alive/src/lib.rs
@@ -24,30 +24,16 @@ pub struct Plugin {
 	enabled:      bool
 }
 
-impl Plugin {
-	fn config(&mut self) -> Result<(), String> {
-		let cfg = read_cfg::<Config>("alive.yml")?;
-		self.enabled = cfg.enabled;
-		if self.enabled {
-			self.periodicity = cfg.periodicity;
-		}
-		Ok(())
-	}
-}
-
 pub fn new() -> Result<Plugin, String> {
-	let mut new_plugin = Plugin {
-		enabled:      false,
-		last_call_ts: 0,
-		periodicity:  0
-	};
-
-	new_plugin.config()?;
-
-	if new_plugin.enabled {
-		Ok(new_plugin)
+	let cfg = read_cfg::<Config>("alive.yml")?;
+	if cfg.enabled {
+		Ok(Plugin {
+			enabled:      true,
+			last_call_ts: 0,
+			periodicity:  cfg.periodicity
+		})
 	} else {
-		Err("Alive plugins disabled".into())
+		Err("Alive plugin disabled".into())
 	}
 }
 

--- a/agent/agent_plugins/command_runner/Cargo.toml
+++ b/agent/agent_plugins/command_runner/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 agent_lib = {path="../../agent_lib"}
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde_json = "1.0.13"
+serde = "1.0.37"
+serde_derive = "1.0.37"

--- a/agent/agent_plugins/file_checker/Cargo.toml
+++ b/agent/agent_plugins/file_checker/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde_json = "1.0.13"
+serde = "1.0.37"
+serde_derive = "1.0.37"
 fs_extra = "1.1.0"
 agent_lib = {path="../../agent_lib"}

--- a/agent/agent_plugins/file_checker/src/lib.rs
+++ b/agent/agent_plugins/file_checker/src/lib.rs
@@ -62,7 +62,7 @@ impl Plugin {
 				}
 			);
 		}
-		return Ok(());
+		Ok(())
 	}
 }
 

--- a/agent/agent_plugins/process_counter/Cargo.toml
+++ b/agent/agent_plugins/process_counter/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 agent_lib = {path="../../agent_lib"}
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde_json = "1.0.13"
+serde = "1.0.37"
+serde_derive = "1.0.37"

--- a/agent/agent_plugins/process_counter/src/lib.rs
+++ b/agent/agent_plugins/process_counter/src/lib.rs
@@ -41,7 +41,7 @@ impl Plugin {
 				.insert(self.processes[i].clone(), cfg.periodicity_arr[i]);
 			self.last_call_map.insert(self.processes[i].clone(), 0);
 		}
-		return Ok(());
+		Ok(())
 	}
 }
 

--- a/agent/agent_plugins/system_monitor/Cargo.toml
+++ b/agent/agent_plugins/system_monitor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 agent_lib = {path="../../agent_lib"}
-serde_json = "1.0"
-sysinfo = "0.5.1"
-serde_derive = "1.0"
-serde = "1.0"
+serde_json = "1.0.13"
+sysinfo = "0.5.4"
+serde_derive = "1.0.37"
+serde = "1.0.37"

--- a/agent/agent_plugins/system_monitor/src/lib.rs
+++ b/agent/agent_plugins/system_monitor/src/lib.rs
@@ -68,37 +68,26 @@ impl AgentPlugin for Plugin {
 
 	fn gather(&mut self) -> Result<String, String> {
 		self.last_call_ts = current_ts();
-
 		self.sys.refresh_all();
-
 		let mut fs_state: Vec<HashMap<&str, String>> = Vec::new();
 
 		for disk in self.sys.get_disks() {
 			let mut disk_state = HashMap::new();
-
 			disk_state.insert("mount_point", format!("{}", disk.get_mount_point().to_string_lossy()));
-
 			disk_state.insert("available_space", format!("{}", disk.get_available_space()));
-
 			disk_state.insert("total_space", format!("{}", disk.get_total_space()));
-
 			fs_state.push(disk_state);
 		}
 
 		let mut memory_map = HashMap::new();
-
 		memory_map.insert("total_memory", format!("{}", self.sys.get_total_memory()));
-
 		memory_map.insert("used_memory", format!("{}", self.sys.get_used_memory()));
 
 		let mut swap_map = HashMap::new();
-
 		swap_map.insert("total_swap", format!("{}", self.sys.get_total_swap()));
-
 		swap_map.insert("used_swap", format!("{}", self.sys.get_used_swap()));
 
 		let processors = self.sys.get_processor_list();
-
 		let mut processor_map = HashMap::new();
 
 		let total_usage: f32 =
@@ -107,11 +96,8 @@ impl AgentPlugin for Plugin {
 		processor_map.insert("total_usage", total_usage);
 
 		let mut network_map = HashMap::new();
-
 		let network = self.sys.get_network();
-
 		network_map.insert("in", format!("{}", network.get_income()));
-
 		network_map.insert("out", format!("{}", network.get_outcome()));
 
 		let machine_state = MachineState {
@@ -121,7 +107,7 @@ impl AgentPlugin for Plugin {
 			processor_map,
 			network_map
 		};
-
+		
 		Ok(serde_json::to_string(&machine_state).map_err(|e| e.to_string())?)
 	}
 

--- a/agent/agent_plugins/system_monitor/src/lib.rs
+++ b/agent/agent_plugins/system_monitor/src/lib.rs
@@ -4,9 +4,9 @@ extern crate agent_lib;
 extern crate serde_json;
 extern crate sysinfo;
 
-use sysinfo::{DiskExt, NetworkExt, ProcessorExt, System, SystemExt};
 use agent_lib::{current_ts, read_cfg, AgentPlugin};
 use std::collections::HashMap;
+use sysinfo::{DiskExt, NetworkExt, ProcessorExt, System, SystemExt};
 
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/agent/agent_plugins/system_monitor/src/lib.rs
+++ b/agent/agent_plugins/system_monitor/src/lib.rs
@@ -37,11 +37,10 @@ impl Plugin {
 	fn config(&mut self) -> Result<(), String> {
 		let cfg = read_cfg::<Config>("system_monitor.yml")?;
 		self.enabled = cfg.enabled;
-		if !self.enabled {
-			return Ok(());
+		if self.enabled {
+			self.periodicity = cfg.periodicity;
 		}
-		self.periodicity = cfg.periodicity;
-		return Ok(());
+		Ok(())
 	}
 }
 

--- a/agent/plugins/Cargo.toml
+++ b/agent/plugins/Cargo.toml
@@ -16,8 +16,8 @@ system_monitor = {path = "../agent_plugins/system_monitor"}
 command_runner = {path = "../agent_plugins/command_runner"}
 
 agent_lib = {path = "../agent_lib"}
-log = "0.4.0"
+log = "0.4.1"
 env_logger = "0.5.6"
 
 [build-dependencies]
-cargo_metadata = "0.4.0"
+cargo_metadata = "0.5.4"

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
 			sender.arbitrate(&mut **p, &mut payload);
 		}
 
-		debug!("Paytload content: {:?}", payload);
+		debug!("Payload content: {:?}", payload);
 
 		if !payload.is_empty() {
 			let serialized_payload = serde_json::to_string(&payload).expect("Can't serialize payload");

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,17 +2,16 @@
 extern crate log;
 extern crate agent_lib;
 extern crate env_logger;
-extern crate futures;
 extern crate hostname;
 extern crate plugins;
 extern crate serde_json;
 extern crate tokio;
 
 use agent_lib::{current_ts, get_yml_config, AgentPlugin, Status};
-use futures::Future;
 use std::net::SocketAddr;
 use std::{thread, time};
 use tokio::net::TcpStream;
+use tokio::prelude::Future;
 
 
 fn main() {

--- a/receptor/Cargo.toml
+++ b/receptor/Cargo.toml
@@ -4,30 +4,29 @@ version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
-tokio-core = "0.1.15"
-tokio = "0.1.3"
-futures = "0.1.18"
+tokio-core = "0.1.16"
+tokio = "0.1.5"
 time = "0.1.39"
 
-hyper = "0.11"
+hyper = "0.11.25"
 hyper-staticfile = "0.1.1"
 
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-yaml-rust = "0.4"
+serde = "1.0.37"
+serde_derive = "1.0.37"
+serde_json = "1.0.13"
+yaml-rust = "0.4.0"
 
 fs_extra = "1.1.0"
-walkdir = "2"
+walkdir = "2.1.4"
 
-log = "0.4.0"
+log = "0.4.1"
 env_logger = "0.5.6"
 
 receptor_lib = {path="receptor_lib"}
 plugins = {path="plugins"}
 
 [dependencies.rusqlite]
-version = "0.11.0"
+version = "0.13.0"
 features = ["bundled"]
 
 [workspace]

--- a/receptor/plugins/Cargo.toml
+++ b/receptor/plugins/Cargo.toml
@@ -13,8 +13,8 @@ sync_check = {path = "../receptor_plugins/sync_check"}
 comparator = {path = "../receptor_plugins/comparator"}
 
 receptor_lib = {path = "../receptor_lib"}
-log = "0.4.0"
+log = "0.4.1"
 env_logger = "0.5.6"
 
 [build-dependencies]
-cargo_metadata = "0.4.0"
+cargo_metadata = "0.5.4"

--- a/receptor/plugins/build.rs
+++ b/receptor/plugins/build.rs
@@ -55,12 +55,12 @@ fn main() {
 	copy(
 		"../inquisitor-receptor.service",
 		"../target/debug/inquisitor-receptor.service"
-	);
+	).unwrap();
 
 	copy(
 		"../inquisitor-receptor.service",
 		"../target/release/inquisitor-receptor.service"
-	);
+	).unwrap();
 
 	copy("../receptor_config.yml", "../target/debug/receptor_config.yml").unwrap();
 

--- a/receptor/receptor_lib/Cargo.toml
+++ b/receptor/receptor_lib/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 fs_extra = "1.1.0"
-yaml-rust = "0.4"
-url="1.7.0"
-hyper = "0.11"
+yaml-rust = "0.4.0"
+url= "1.7.0"
+hyper = "0.11.25"
 shared_lib = {path="../../shared_lib"}
 
 [dependencies.rusqlite]
-version = "0.11.0"
+version = "0.13.0"
 features = ["bundled"]

--- a/receptor/receptor_lib/src/lib.rs
+++ b/receptor/receptor_lib/src/lib.rs
@@ -5,7 +5,6 @@ pub mod utils;
 
 use rusqlite::Connection;
 pub use shared_lib::{current_ts, get_yml_config, read_cfg, Status};
-use std::string::String;
 
 pub trait ReceptorPlugin {
 	fn name(&self) -> String;

--- a/receptor/receptor_lib/src/utils.rs
+++ b/receptor/receptor_lib/src/utils.rs
@@ -9,7 +9,7 @@ use self::url::Url;
 use std::collections::HashMap;
 
 pub fn get_url_params(req: &Request) -> HashMap<String, String> {
-	let parsed_url = Url::parse(&format!("http://badhyper.io/{}", req.uri().as_ref())).unwrap();
+	let parsed_url = Url::parse(&format!("http://example.com/{}", req.uri())).unwrap();
 
 	let hash_query: HashMap<String, String> = parsed_url.query_pairs().into_owned().collect();
 

--- a/receptor/receptor_plugins/comparator/Cargo.toml
+++ b/receptor/receptor_plugins/comparator/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 receptor_lib = {path="../../receptor_lib"}
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
-log = "0.4.0"
+serde_json = "1.0.13"
+serde = "1.0.37"
+serde_derive = "1.0.37"
+log = "0.4.1"
 env_logger = "0.5.6"
 
 [dependencies.rusqlite]
-version = "0.11.0"
+version = "0.13.0"
 features = ["bundled"]

--- a/receptor/receptor_plugins/comparator/src/lib.rs
+++ b/receptor/receptor_plugins/comparator/src/lib.rs
@@ -9,8 +9,6 @@ extern crate env_logger;
 
 use receptor_lib::{current_ts, read_cfg, ReceptorPlugin};
 use rusqlite::Connection;
-use std::string::String;
-use std::vec::Vec;
 use std::collections::HashMap;
 
 
@@ -63,7 +61,7 @@ pub fn new() -> Result<Plugin, String> {
 	if new_plugin.enabled {
 		Ok(new_plugin)
 	} else {
-		Err("Sync check disabled".into())
+		Err("Comparator disabled".into())
 	}
 }
 
@@ -79,14 +77,16 @@ impl ReceptorPlugin for Plugin {
 			let key = &self.keys[z];
 			let mut raw_data = db_conn
 				.prepare(
-					"SELECT sender, message FROM agent_status WHERE ts_received > :ts_received AND plugin_name = :plugin_name;"
+					"SELECT sender, message FROM agent_status WHERE ts_received > :ts_received AND plugin_name = \
+					 :plugin_name;"
 				)
 				.map_err(|e| e.to_string())?;
 
 			let raw_iter = raw_data
-				.query_map_named(&[(":ts_received", &self.last_call_ts), (":plugin_name", &key[0])], |row| {
-					(row.get(0), row.get(1))
-				})
+				.query_map_named(
+					&[(":ts_received", &self.last_call_ts), (":plugin_name", &key[0])],
+					|row| (row.get(0), row.get(1))
+				)
 				.map_err(|e| e.to_string())?;
 
 			let mut data: Vec<(String, String)> = Vec::new();
@@ -100,8 +100,8 @@ impl ReceptorPlugin for Plugin {
 				debug!("Original object: {:?} produced from: {}", &obj, &message);
 				for k in key.iter().skip(1) {
 					let a1 = obj.clone();
-					debug!("Tryinga find: '{}' in {:?}", k, &a1);
-					let a2  = match a1.get(k) {
+					debug!("Trying to find: '{}' in {:?}", k, &a1);
+					let a2 = match a1.get(k) {
 						Some(v) => v,
 						_ => continue
 					};
@@ -109,7 +109,7 @@ impl ReceptorPlugin for Plugin {
 					obj = (*a2).clone();
 				}
 				debug!("Getting value from: {}", obj);
-				let val  = match obj.as_str() {
+				let val = match obj.as_str() {
 					Some(v) => v,
 					_ => continue
 				};

--- a/receptor/receptor_plugins/comparator/src/lib.rs
+++ b/receptor/receptor_plugins/comparator/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate receptor_lib;
 extern crate rusqlite;
-#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
@@ -46,7 +45,7 @@ impl Plugin {
 		for key in cfg.keys {
 			self.keys.push(key);
 		}
-		return Ok(());
+		Ok(())
 	}
 }
 
@@ -96,15 +95,13 @@ impl ReceptorPlugin for Plugin {
 				data.push((sender, message));
 			}
 
-			for n in 0..data.len() {
-				let message = &data[n].1;
-				let sender = &data[n].0;
+			for (sender, message) in data {
 				let mut obj: serde_json::Value = serde_json::from_str(&message).map_err(|e| e.to_string())?;
 				debug!("Original object: {:?} produced from: {}", &obj, &message);
-				for i in 1..key.len() {
+				for k in key.iter().skip(1) {
 					let a1 = obj.clone();
-					debug!("Tryinga find: '{}' in {:?}", &key[i], &a1);
-					let a2  = match a1.get(&key[i]) {
+					debug!("Tryinga find: '{}' in {:?}", k, &a1);
+					let a2  = match a1.get(k) {
 						Some(v) => v,
 						_ => continue
 					};
@@ -124,7 +121,7 @@ impl ReceptorPlugin for Plugin {
 				debug!("{} {} {}", val, operator, comparator);
 
 				if operator == "<" {
-					let fval = val.trim_right_matches("\n").parse::<f64>().map_err(|e| e.to_string())?;
+					let fval = val.trim_right_matches('\n').parse::<f64>().map_err(|e| e.to_string())?;
 					let fcomparator = comparator.parse::<f64>().map_err(|e| e.to_string())?;
 					if fval < fcomparator {
 						let mut warning: HashMap<String, String> = HashMap::new();
@@ -134,7 +131,7 @@ impl ReceptorPlugin for Plugin {
 						results.push(warning);
 					}
 				} else if operator == ">" {
-					let fval = val.trim_right_matches("\n").parse::<f64>().map_err(|e| e.to_string())?;
+					let fval = val.trim_right_matches('\n').parse::<f64>().map_err(|e| e.to_string())?;
 					let fcomparator = comparator.parse::<f64>().map_err(|e| e.to_string())?;
 					if fval > fcomparator {
 						let mut warning: HashMap<String, String> = HashMap::new();

--- a/receptor/receptor_plugins/sync_check/Cargo.toml
+++ b/receptor/receptor_plugins/sync_check/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
 receptor_lib = {path="../../receptor_lib"}
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde_json = "1.0.13"
+serde = "1.0.37"
+serde_derive = "1.0.37"
 
 [dependencies.rusqlite]
-version = "0.11.0"
+version = "0.13.0"
 features = ["bundled"]

--- a/receptor/receptor_plugins/sync_check/src/lib.rs
+++ b/receptor/receptor_plugins/sync_check/src/lib.rs
@@ -27,11 +27,10 @@ impl Plugin {
 	fn config(&mut self) -> Result<(), String> {
 		let cfg = read_cfg::<Config>("sync_check.yml")?;
 		self.enabled = cfg.enabled;
-		if !self.enabled {
-			return Ok(());
+		if self.enabled {
+			self.periodicity = cfg.periodicity;
 		}
-		self.periodicity = cfg.periodicity;
-		return Ok(());
+		Ok(())
 	}
 }
 

--- a/receptor/receptor_plugins/sync_check/src/lib.rs
+++ b/receptor/receptor_plugins/sync_check/src/lib.rs
@@ -7,8 +7,6 @@ extern crate serde_derive;
 use receptor_lib::{current_ts, read_cfg, ReceptorPlugin};
 use rusqlite::Connection;
 use std::collections::HashMap;
-use std::string::String;
-
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Config {

--- a/receptor/src/main.rs
+++ b/receptor/src/main.rs
@@ -2,7 +2,6 @@ mod database;
 
 extern crate env_logger;
 extern crate fs_extra;
-extern crate futures;
 extern crate hyper;
 #[macro_use]
 extern crate log;
@@ -14,8 +13,6 @@ extern crate tokio;
 extern crate tokio_core;
 
 use database::{get_connection, initialize_database};
-use futures::Future;
-use futures::Stream;
 use hyper::server::{Http, Request, Response, Service};
 use hyper::{Method, StatusCode};
 use receptor_lib::ReceptorPlugin;
@@ -24,6 +21,8 @@ use receptor_lib::{get_yml_config, Status};
 use rusqlite::Connection;
 use tokio::io::AsyncRead;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::prelude::{Future, Stream};
+use tokio::prelude::future;
 use tokio_core::reactor::Core;
 use std::vec::Vec;
 use std::{thread, time};
@@ -120,7 +119,7 @@ impl Service for DataServer {
 				_ => response.set_status(StatusCode::NotFound)
 			};
 
-			Box::new(futures::future::ok(response))
+			Box::new(future::ok(response))
 		} else if req.path() == "/plugin_list" {
 			let mut response = Response::new();
 
@@ -153,11 +152,11 @@ impl Service for DataServer {
 				_ => response.set_status(StatusCode::NotFound)
 			}
 
-			Box::new(futures::future::ok(response))
+			Box::new(future::ok(response))
 		} else {
 			let mut response = Response::new();
 			response.set_status(StatusCode::NotFound);
-			Box::new(futures::future::ok(response))
+			Box::new(future::ok(response))
 		}
 	}
 }
@@ -318,7 +317,7 @@ fn main() {
 				.map_err(|_| ())
 		);
 
-		core.run(futures::future::empty::<(), ()>()).unwrap();
+		core.run(future::empty::<(), ()>()).unwrap();
 	});
 
 	// Listen for incoming statuses from agents and process them

--- a/receptor/src/main.rs
+++ b/receptor/src/main.rs
@@ -19,13 +19,12 @@ use receptor_lib::ReceptorPlugin;
 use receptor_lib::utils::get_url_params;
 use receptor_lib::{get_yml_config, Status};
 use rusqlite::Connection;
+use std::{thread, time};
 use tokio::io::AsyncRead;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::prelude::{Future, Stream};
 use tokio::prelude::future;
+use tokio::prelude::{Future, Stream};
 use tokio_core::reactor::Core;
-use std::vec::Vec;
-use std::{thread, time};
 
 
 struct DataServer {

--- a/shared_lib/Cargo.toml
+++ b/shared_lib/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
-serde_yaml = "0.7"
+serde = "1.0.37"
+serde_derive = "1.0.37"
+serde_yaml = "0.7.3"
 fs_extra = "1.1.0"
-yaml-rust = "0.4"
-url="1.7.0"
-log = "0.4.0"
+yaml-rust = "0.4.0"
+url= "1.7.0"
+log = "0.4.1"
 env_logger = "0.5.6"

--- a/shared_lib/src/lib.rs
+++ b/shared_lib/src/lib.rs
@@ -52,7 +52,7 @@ pub fn get_yml_config_string(name: &str) -> Result<String, String> {
 	cfg_file_path.pop();
 	cfg_file_path.push(name);
 	debug!("Reading config from: {:?}", cfg_file_path);
-	return Ok(read_to_string(&cfg_file_path).map_err(|e| e.to_string())?);
+	Ok(read_to_string(&cfg_file_path).map_err(|e| e.to_string())?)
 }
 
 pub fn read_cfg<ConfigT>(name: &str) -> Result<ConfigT, String>
@@ -61,5 +61,5 @@ where
 {
 	let cfg_str = get_yml_config_string(name)?;
 	let cfg: ConfigT = serde_yaml::from_str(&cfg_str).map_err(|e| e.to_string())?;
-	return Ok(cfg);
+	Ok(cfg)
 }


### PR DESCRIPTION
All clippy suggestions except #34 are implemented. Only real logical change is using the Futures library included in tokio rather than it being a hard dependency. This was done because of an API change between Futures and Tokio. This should also make it easy to update when Futures .3 hits with more breaking changes. 

Cargo_metadata has updated to fix the bug you found and mentioned in #10, but you should probably check this out and try to compile it before merging. 