### PR TITLE
Implements naming convention and removes config files from build process

### DIFF
--- a/agent/agent_plugins/alive/Cargo.toml
+++ b/agent/agent_plugins/alive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "alive"
+name = "inquisitor_agent_alive"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 

--- a/agent/agent_plugins/command_runner/Cargo.toml
+++ b/agent/agent_plugins/command_runner/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "command_runner"
+name = "inquisitor_agent_command_runner"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 

--- a/agent/agent_plugins/file_checker/Cargo.toml
+++ b/agent/agent_plugins/file_checker/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "file_checker"
+name = "inquisitor_agent_file_checker"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 

--- a/agent/agent_plugins/process_counter/Cargo.toml
+++ b/agent/agent_plugins/process_counter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "process_counter"
+name = "inquisitor_agent_process_counter"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 

--- a/agent/agent_plugins/system_monitor/Cargo.toml
+++ b/agent/agent_plugins/system_monitor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "system_monitor"
+name = "inquisitor_agent_system_monitor"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 

--- a/agent/plugins/Cargo.toml
+++ b/agent/plugins/Cargo.toml
@@ -9,11 +9,11 @@ name = "plugins"
 path = "src/lib.rs"
 
 [dependencies]
-alive = {path = "../agent_plugins/alive"}
-file_checker = {path = "../agent_plugins/file_checker"}
-process_counter = {path = "../agent_plugins/process_counter"}
-system_monitor = {path = "../agent_plugins/system_monitor"}
-command_runner = {path = "../agent_plugins/command_runner"}
+inquisitor_agent_alive = {path = "../agent_plugins/alive"}
+inquisitor_agent_file_checker = {path = "../agent_plugins/file_checker"}
+inquisitor_agent_process_counter = {path = "../agent_plugins/process_counter"}
+inquisitor_agent_system_monitor = {path = "../agent_plugins/system_monitor"}
+inquisitor_agent_command_runner = {path = "../agent_plugins/command_runner"}
 
 inquisitor_lib = {path = "../../inquisitor_lib"}
 log = "0.4.1"

--- a/agent/plugins/build.rs
+++ b/agent/plugins/build.rs
@@ -1,8 +1,6 @@
 extern crate cargo_metadata;
 
-use std::fs::{copy, create_dir_all, File};
-use std::io::Write;
-use std::path::Path;
+use std::{fs::File, io::Write, path::Path};
 
 fn main() {
 	// Get list of 'dependencies'
@@ -46,36 +44,4 @@ fn main() {
 			plugins.join(", ")
 		).as_bytes()
 	).unwrap();
-
-	create_dir_all("../target/debug").unwrap();
-
-	create_dir_all("../target/release").unwrap();
-
-	copy(
-		"../inquisitor-agent.service",
-		"../target/debug/inquisitor-agent.service"
-	).unwrap();
-
-	copy(
-		"../inquisitor-agent.service",
-		"../target/release/inquisitor-agent.service"
-	).unwrap();
-
-	copy("../agent_config.yml", "../target/debug/agent_config.yml").unwrap();
-
-	copy("../agent_config.yml", "../target/release/agent_config.yml").unwrap();
-
-	for plugin in plugins {
-		println!("{}", plugin);
-
-		copy(
-			format!("../agent_plugins/{x}/{x}.yml", x = plugin),
-			format!("../target/debug/{x}.yml", x = plugin)
-		).unwrap();
-
-		copy(
-			format!("../agent_plugins/{x}/{x}.yml", x = plugin),
-			format!("../target/release/{x}.yml", x = plugin)
-		).unwrap();
-	}
 }

--- a/receptor/plugins/Cargo.toml
+++ b/receptor/plugins/Cargo.toml
@@ -9,8 +9,8 @@ name = "plugins"
 path = "src/lib.rs"
 
 [dependencies]
-sync_check = {path = "../receptor_plugins/sync_check"}
-comparator = {path = "../receptor_plugins/comparator"}
+inquisitor_receptor_sync_check = {path = "../receptor_plugins/sync_check"}
+inquisitor_receptor_comparator = {path = "../receptor_plugins/comparator"}
 
 inquisitor_lib = {path = "../../inquisitor_lib"}
 log = "0.4.1"

--- a/receptor/plugins/build.rs
+++ b/receptor/plugins/build.rs
@@ -1,10 +1,6 @@
 extern crate cargo_metadata;
 
-use std::fs::File;
-use std::fs::copy;
-use std::fs::create_dir_all;
-use std::io::Write;
-use std::path::Path;
+use std::{fs::File, io::Write, path::Path};
 
 fn main() {
 	// Get list of 'dependencies'
@@ -47,34 +43,4 @@ fn main() {
 			plugins.join(", ")
 		).as_bytes()
 	).unwrap();
-
-	create_dir_all("../target/debug").unwrap();
-
-	create_dir_all("../target/release").unwrap();
-
-	copy(
-		"../inquisitor-receptor.service",
-		"../target/debug/inquisitor-receptor.service"
-	).unwrap();
-
-	copy(
-		"../inquisitor-receptor.service",
-		"../target/release/inquisitor-receptor.service"
-	).unwrap();
-
-	copy("../receptor_config.yml", "../target/debug/receptor_config.yml").unwrap();
-
-	copy("../receptor_config.yml", "../target/release/receptor_config.yml").unwrap();
-
-	for plugin in plugins {
-		copy(
-			format!("../receptor_plugins/{x}/{x}.yml", x = plugin),
-			format!("../target/debug/{x}.yml", x = plugin)
-		).unwrap();
-
-		copy(
-			format!("../receptor_plugins/{x}/{x}.yml", x = plugin),
-			format!("../target/release/{x}.yml", x = plugin)
-		).unwrap();
-	}
 }

--- a/receptor/receptor_plugins/comparator/Cargo.toml
+++ b/receptor/receptor_plugins/comparator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "comparator"
+name = "inquisitor_receptor_comparator"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 

--- a/receptor/receptor_plugins/sync_check/Cargo.toml
+++ b/receptor/receptor_plugins/sync_check/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sync_check"
+name = "inquisitor_receptor_sync_check"
 version = "0.3.0"
 authors = ["George Hosu <george@cerebralab.com>"]
 


### PR DESCRIPTION
Closes #46 and closes #39. 

This does not make any API changes, nor does it change how the server sees the plugins. Only the crate name is changed, not the plugin names. 